### PR TITLE
Updated Response[A] to support OrNotFound, OrElse and Sum combinators

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import scala.sys.process._
+import scala.sys.process.*
 import laika.rewrite.link.LinkConfig
 import laika.rewrite.link.ApiLinks
 import laika.theme.Theme
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
-ThisBuild / tlBaseVersion := "0.6" // your current series x.y
+ThisBuild / tlBaseVersion := "0.7" // your current series x.y
 
 ThisBuild / organization := "org.creativescala"
 ThisBuild / organizationName := "Creative Scala"
@@ -71,16 +71,15 @@ lazy val commonSettings = Seq(
   )
 )
 
-lazy val root = crossProject(JSPlatform, JVMPlatform)
+lazy val krop = crossProject(JSPlatform, JVMPlatform)
   .in(file("."))
   .settings(moduleName := "krop")
-lazy val rootJs =
-  root.js.aggregate(
-    core.js
-  )
+
+lazy val kropJs =
+  krop.js.aggregate(core.js)
 
 lazy val rootJvm =
-  root.jvm.aggregate(
+  krop.jvm.aggregate(
     core.jvm,
     examples,
     unidocs
@@ -171,6 +170,6 @@ lazy val examples = project
     // developers. If you don't set this, Krop runs in production mode.
     run / javaOptions += "-Dkrop.mode=development",
     run / fork := true,
-    libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.4.11" % Runtime
+    libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.4.12" % Runtime
   )
   .dependsOn(core.jvm)

--- a/core/shared/src/main/scala/krop/route/Param.scala
+++ b/core/shared/src/main/scala/krop/route/Param.scala
@@ -47,7 +47,7 @@ sealed abstract class Param[A] extends Product, Serializable {
   /** Gets a human-readable description of this `Param`. */
   def describe: String =
     this match {
-      case All(name, _, _) => s"${name}*"
+      case All(name, _, _) => s"$name*"
       case One(name, _, _) => name
     }
 
@@ -108,21 +108,21 @@ object Param {
       * convert from A to B and B to A.
       */
     def imap[B](f: A => B)(g: B => A): One[B] =
-      One(name, v => parse(v).map(f), b => unparse(g(b)))
+      One(name, parse(_).map(f), g.andThen(unparse))
   }
 
   /** A `Param` that matches a single `Int` parameter */
   val int: Param.One[Int] =
-    Param.One("<Int>", str => Try(str.toInt), i => i.toString)
+    Param.One("<Int>", str => Try(str.toInt), _.toString)
 
   /** A `Param` that matches a single `String` parameter */
   val string: Param.One[String] =
-    Param.One("<String>", str => Success(str), identity)
+    Param.One("<String>", Success(_), identity)
 
   /** `Param` that simply accumulates all parameters as a `Seq[String]`.
     */
   val seq: Param.All[Seq[String]] =
-    Param.All("<String>", seq => Success(seq), identity)
+    Param.All("<String>", Success(_), identity)
 
   /** `Param` that matches all parameters and converts them to a `String` by
     * adding `separator` between matched elements. The inverse splits on this
@@ -141,7 +141,7 @@ object Param {
   def lift[A](one: One[A]): Param.All[Seq[A]] =
     Param.All(
       one.name,
-      seq => seq.traverse(one.parse),
-      as => as.map(one.unparse)
+      _.traverse(one.parse),
+      _.map(one.unparse)
     )
 }

--- a/core/shared/src/main/scala/krop/route/Request.scala
+++ b/core/shared/src/main/scala/krop/route/Request.scala
@@ -21,7 +21,7 @@ import cats.syntax.all.*
 import org.http4s.EntityDecoder
 import org.http4s.Media
 import org.http4s.Method
-import org.http4s.{Request as Http4sRequest}
+import org.http4s.Request as Http4sRequest
 
 /** A [[krop.route.Request]] describes a pattern within a [[org.http4s.Request]]
   * that will be routed to a handler. For example, it can look for a particular


### PR DESCRIPTION
@noelwelsh  Apart from the core changes in `Response.scala`, I have also made some cleanup and nit changes in a couple of other changes. Happy to drop them if you feel they don't align with the current project standard.

Initially, I had implemented `OrElse` how we discussed in our last session - returning `Response[Either[I, O]]`. After discussing with a friend (who is a lot more smarter than I am), I named it `Sum` (because it puts I and O into an `Either[I, O]`). But added an `OrElse` (congruent to the `OrElse` on `Route` - do this _or else_ do that). Let me know your thoughts.