### PR TITLE
Make Param.all[A] use an implicit StringCodec[A]

### DIFF
--- a/core/jvm/src/test/scala/krop/route/ParamSuite.scala
+++ b/core/jvm/src/test/scala/krop/route/ParamSuite.scala
@@ -70,7 +70,7 @@ class ParamSuite extends FunSuite {
       Seq(Seq() -> "", Seq("a") -> "a", Seq("a", "b", "c") -> "a,b,c")
     )
     paramAllDecodesValid(
-      Param.all(Param.int),
+      Param.all[Int],
       Seq(
         Seq() -> Seq(),
         Seq("1") -> Seq(1),

--- a/core/shared/src/main/scala/krop/route/Param.scala
+++ b/core/shared/src/main/scala/krop/route/Param.scala
@@ -120,6 +120,6 @@ object Param {
   def separatedString(separator: String): Param.All[String] =
     Param.All(SeqStringCodec.separatedString(separator))
 
-  def all[A](param: Param.One[A]): Param.All[Seq[A]] =
-    Param.All(SeqStringCodec.all(using param.codec))
+  def all[A](using codec: StringCodec[A]): Param.All[Seq[A]] =
+    Param.All(SeqStringCodec.all(using codec))
 }

--- a/docs/src/pages/controller/route/paths.md
+++ b/docs/src/pages/controller/route/paths.md
@@ -2,6 +2,7 @@
 
 ```scala mdoc:invisible
 import krop.all.*
+import krop.route.StringCodec.given
 ```
 
 A @:api(krop.route.Path) represents a pattern to match against the path component of the request's URI. `Paths` are created by calling the `/` method on a `Path` to add segments to the pattern. For example
@@ -163,7 +164,7 @@ A `Param.One[A]` can be lifted to a `Param.All[Seq[A]]` that uses the given
 `Param.One` for every element in the `Seq`.
 
 ```scala mdoc:silent
-val intParams = Param.all(intParam)
+val intParams = Param.all[Int]
 ```
 ```scala mdoc
 intParams.encode(Seq(1, 2, 3))


### PR DESCRIPTION
This allows for reducing the amount of ceremonies for creating a Route that uses it

resolves #24 